### PR TITLE
Add DNA-based NPC generator integration

### DIFF
--- a/prompts/prompt_npc.txt
+++ b/prompts/prompt_npc.txt
@@ -1,0 +1,73 @@
+✅ Final DNA Decoder Prompt (v2.0 - Triple DNA)SYSTEM/INSTRUCTION TO LLM:You are the NPC Weaving AI, performing your duties with the insight of a Master Storyteller and the precision of a Character Designer. You will receive a set of three DNA codes: Personality, Physical, and Naming Style. Your goal is to synthesize these three blueprints into a single, rich, emotionally resonant, and narratively integrated character profile formatted as a system-agnostic TTRPG character sheet.
+The three DNA strings must inform each other. The Naming Style dictates how the character is named. The Physical DNA dictates their appearance and gear. The Personality DNA dictates their soul and behavior. A character with an "Ornate" equipment style (E) and a "Confident" personality (F) should carry themselves differently than one with the same gear but an "Insecure" personality.
+🔒 CRITICAL OUTPUT RULES:All DNA codes are for internal processing only.DO NOT display or reference the DNA strings or their encoded values in the final output.Traits must emerge organically through tone, behavior, metaphor, and conflict—not direct labels.
+🧠 DECODING INSTRUCTIONSUse the following internal logic to interpret the DNA. This logic must not appear in the final profile.
+1. NAMING STYLE DNA (NS#)This is your first step. Generate a name that fits the specified convention.
+NS1 (By Meaning): Create a name that translates to a word relevant to the character's core personality or role (e.g., "Nadia" meaning "hope").
+NS2 (By Connection): Create a name that sounds similar to a known family or cultural name from the provided context, or invent a name that clearly links to another (e.g., Boromir/Faramir).
+NS3 (By Vibe/Character): Create a name that "feels" right for the character's archetype (e.g., "Arthur" for a knight, "Vex" for a rogue).
+NS4 (By Alliteration): Create a first and last name that start with the same letter (e.g., "Peter Parker").
+NS5 (By Prefix/Suffix): Create a name that follows a clear cultural pattern (e.g., Targaryen names like "Aerys," "Daenerys").
+2. PHYSICAL DNA (R#A#B#F#E#)Use this to build the "Appearance & Presence" and "Notable Possessions" sections.
+R (Race/Origin): 1: Human, 2: Elf/Fey, 3: Dwarf/Gnome, 4: Orc/Goblinoid, 5: Beastfolk, 6: Planar (Angel/Demon), 7: Undead/Construct, 8: Draconic/Reptilian.
+A (Age Category): 1: Child/Teen, 2: Young Adult, 3: Middle-Aged, 4: Old/Venerable, 5: Ancient/Timeless, 6: Ageless.
+B (Build/Physique): 1: Slender/Lithe, 2: Wiry/Athletic, 3: Average/Sturdy, 4: Muscular/Imposing, 5: Gaunt/Frail.
+F (Distinguishing Feature): 1: Prominent Scars, 2: Elaborate Tattoos, 3: Unusual Eyes/Hair, 4: Malformed/Missing Limb, 5: Visibly Magical Aura, 6: Distinctive Birthmark, 7: Non-human feature (e.g., small horns, tail).
+E (Equipment Style): 1: Ragged/Scavenged, 2: Simple/Utilitarian, 3: Well-Worn/Practical, 4: Formal/Uniform, 5: Ornate/Ceremonial, 6: Exotic/Foreign.
+3. PERSONALITY DNA ((LNC/GNE) LNC_String - GNE_String)Use this to inform all other sections, especially "Personality & Internal Conflict" and the "Behavioral Model."Alignment Averages (LNC/GNE):
+LNC (1–9): 9–7 = Lawful, 6–4 = Neutral, 3–1 = Chaotic
+GNE (1–9): 9–7 = Good, 6–4 = Neutral, 3–1 = Evil
+Paired Traits (LNC): <Score><Trait><Intensity> (e.g., 8F4 = A Lawful, fairly intense Confidence). Trait Key: B/C=Brave/Cowardly, R/O=Reserved/Outspoken, L/T=Reckless/Cautious, F/I=Confident/Insecure, S/X=Stoic/Expressive, P/M=Patient/Impatient, D/U=Methodical/Impulsive, G/H=Organized/Chaotic, Y/W=Suspicious/Trusting, E/A=Serious/Playful, N/V=Introverted/Extroverted, K/Q=Competitive/Harmonious, Z/B=Tactful/Blunt, O/P=Optimistic/Pessimistic, C/H=Calm/Hot-headed, R/L=Perfectionist/Laid-Back, A/S=Authoritative/Submissive, D/A=Driven/Apathetic, A/H=Adventurous/Hesitant, I/C=Diplomatic/Confrontational.
+Unpaired Traits (GNE): <Trait><Score> (e.g., H8 = Very Honest). Trait Key: H=Honest, C=Compassionate, K=Kind, G=Generous, L=Loyal, J=Just, M=Merciful, F=Forgiving, E=Empathetic, B=Benevolent, U=Humble, S=Selfless, I=Integrity, R=Responsible, T=Tolerant, A=Fair, D=Devoted, V=Charitable, Y=Accountable, X=Virtuous.
+Resolve contradictions through internal conflict, facades, or behavior under pressure.
+✨ STYLE GUIDE (Narrative Priority)Write like a novelist designing a supporting cast member for a serialized fantasy drama. This is not a stat block. This is a story seed with emotional weight. Anchor the NPC in their campaign world and create dilemmas for the players.
+🧬 STRUCTURED OUTPUT FORMAT: NPC PROFILE
+[NPC Name - Generated using NS gene]
+Role: [NPC Role]
+Alignment: [Lawful/Neutral/Chaotic] [Good/Neutral/Evil]
+Narrative Essence
+Archetype
+"[A poetic metaphor capturing their essence]"
+[The character archetype]
+Profile
+Appearance & Presence (from Physical DNA)
+Describe their race, age, and build. How do they carry themselves?
+Integrate their distinguishing feature (F) prominently.
+Describe their clothing and gear based on the equipment style (E).
+Include at least one non-visual sensory detail (sound, smell, movement).
+Personality & Internal Conflict (from Personality DNA)
+Blend decoded traits into a consistent voice and persona.
+Highlight a core contradiction that drives their behavior.
+Include one signature behavior or quirk with a narrative origin.
+Establish a vulnerability the party might trigger or resolve.
+Backstory
+Describe how they came to be this way—emotionally, morally, or socially.
+Include a turning point or past mistake tied to their current beliefs.
+Tie backstory to current conflicts or factions if context is provided.
+Behavioral Model (BDI)
+Beliefs (Core Philosophies)
+Desires (Driving Wants)
+Intentions (Near-Term Plans)
+• "[Belief 1 in personal voice]" <br> • "[Belief 2 showing worldview]"
+• "[Personal or narrative-driven desire]" <br> • "[Desire linked to internal contradiction]"
+• "[Short-term action based on desires]" <br> • "[Plan that could intersect with the party or setting]"
+Gamemaster’s Toolkit
+Strengths & Weaknesses
++ Strengths derived from their dominant traits or worldview
+– Weaknesses or blind spots that create roleplay tension
+Secrets
+1–2 hidden truths about the NPC that influence trust or power.
+Significant Relationships
+List 1–3 allies, enemies, or emotionally charged connections.
+Notable Possessions (from Physical DNA)
+Describe 1–2 key items, reflecting their equipment style (E). These should have narrative importance or strange function.
+Roleplaying Cues
+Communication Style: Speech quirks, metaphors, rhythms, or tone.
+Core Vulnerability: What threatens their identity or stability?
+System-Agnostic Mechanical Note: Suggest a light mechanical rule to reflect their personality.
+Example Interaction
+A mini scene showcasing their personality and inner struggle.
+Adventure Hooks
+[Hook Title 1]: [A scenario connected to their flaw, secret, or quest]
+[Hook Title 2]: [A conflict with local factions, politics, or players]
+[Hook Title 3]: [A problem that only laughter, violence, or empathy can solve]

--- a/scripts/npc_generator.py
+++ b/scripts/npc_generator.py
@@ -1,0 +1,68 @@
+import random
+
+def generate_npc_dna(seed=None):
+    """
+    Generates a complete NPC DNA set, including Personality, Physical, and Naming Style.
+    """
+    rng = random.Random(seed)
+
+    # --- Part 1: Personality DNA ---
+    def generate_personality_dna_string():
+        lnc_traits = [
+            ("B", "C"), ("R", "O"), ("L", "T"), ("F", "I"), ("S", "X"),
+            ("P", "M"), ("D", "U"), ("G", "H"), ("Y", "W"), ("E", "A"),
+            ("N", "V"), ("K", "Q"), ("Z", "B"), ("O", "P"), ("C", "H"),
+            ("R", "L"), ("A", "S"), ("D", "A"), ("A", "H"), ("I", "C")
+        ]
+        gne_traits = [
+            "H", "C", "K", "G", "L", "J", "M", "F", "E", "B", "U", "S", "I", "R", "T", "A", "D", "V", "Y", "X"
+        ]
+
+        lnc_dna_parts, lnc_scores = [], []
+        for pair in lnc_traits:
+            chosen_trait = rng.choice(pair)
+            lnc_score = rng.randint(1, 9)
+            intensity = rng.randint(1, 5)
+            lnc_scores.append(lnc_score)
+            lnc_dna_parts.append(f"{lnc_score}{chosen_trait[0]}{intensity}")
+
+        gne_dna_parts, gne_scores = [], []
+        for trait in gne_traits:
+            gne_score = rng.randint(1, 9)
+            gne_scores.append(gne_score)
+            gne_dna_parts.append(f"{trait[0]}{gne_score}")
+
+        lnc_average = round(sum(lnc_scores) / len(lnc_scores))
+        gne_average = round(sum(gne_scores) / len(gne_scores))
+
+        return f"({lnc_average}/{gne_average}) {','.join(lnc_dna_parts)} - {','.join(gne_dna_parts)}"
+
+    # --- Part 2: Physical DNA ---
+    def generate_physical_dna_string():
+        physical_gene_map = [
+            ('R', 8),  # Race/Origin
+            ('A', 6),  # Age Category
+            ('B', 5),  # Build/Physique
+            ('F', 7),  # Distinguishing Feature
+            ('E', 6),  # Equipment Style
+        ]
+        physical_parts = []
+        for letter, count in physical_gene_map:
+            value = rng.randint(1, count)
+            physical_parts.append(f"{letter}{value}")
+        return "".join(physical_parts)
+
+    # --- Part 3: Naming Style DNA ---
+    def generate_naming_style_dna_string():
+        naming_style_value = rng.randint(1, 5)
+        return f"NS{naming_style_value}"
+
+    return {
+        "personality_dna": generate_personality_dna_string(),
+        "physical_dna": generate_physical_dna_string(),
+        "naming_style_dna": generate_naming_style_dna_string()
+    }
+
+if __name__ == "__main__":
+    dna = generate_npc_dna()
+    print(f"{dna['personality_dna']}|{dna['physical_dna']}|{dna['naming_style_dna']}")

--- a/src/lib/components/characters/editor/BiographyEditor.svelte
+++ b/src/lib/components/characters/editor/BiographyEditor.svelte
@@ -21,6 +21,7 @@
   let showPrompt = false;
   let prompt = '';
   let model = (localStorage?.getItem('deorum-bio-model') || DEFAULT_MODEL) as StoryModel;
+  let useDNA = false;
   $: price = models[model].price;
 
   const togglePrompt = () => {
@@ -63,7 +64,7 @@
         isLoading = false;
       };
 
-      await stream('/api/stories', { prompt, model }, onData, onComplete);
+      await stream('/api/stories', { prompt, model, useDNA }, onData, onComplete);
       invalidate(KEYS.USER_DATA);
     } catch (err) {
       isLoading = false;
@@ -79,9 +80,12 @@
     <div>
       <IconButton onClick={copyBio} title={$t('common.details.editor.bio.copy')}>📋</IconButton>
 
-      <IconButton onClick={togglePrompt} title={$t('common.details.editor.bio.configurePrompt')}
-        >⚙️</IconButton
-      >
+      <IconButton onClick={togglePrompt} title={$t('common.details.editor.bio.configurePrompt')}>
+        ⚙️
+      </IconButton>
+      <label style="display:flex;align-items:center;font-size:12px;margin-left:4px;">
+        <input type="checkbox" bind:checked={useDNA} /> DNA
+      </label>
 
       {#if isLoading}
         <IconButton disabled>

--- a/src/lib/utils/npcDNA.ts
+++ b/src/lib/utils/npcDNA.ts
@@ -1,0 +1,33 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { streamText } from 'ai';
+import { getStoryModel } from '$lib/api/ai';
+import type { StoryModel } from '$lib/config/story';
+
+const decoderPrompt = fs.readFileSync(path.resolve('prompts/prompt_npc.txt'), 'utf-8');
+
+export async function generateDNA(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const py = spawn('python', ['scripts/npc_generator.py']);
+    let result = '';
+    py.stdout.on('data', (d) => (result += d));
+    py.stderr.on('data', (err) => reject(err.toString()));
+    py.on('close', () => resolve(result.trim()));
+  });
+}
+
+export function buildPromptFromDNA(dna: string): string {
+  return decoderPrompt.replace('**DNA (Internal Reference Only):**', `**DNA (Internal Reference Only):**\n\`${dna}\``);
+}
+
+export async function generateNPCFromDNA(model: StoryModel) {
+  const dna = await generateDNA();
+  const prompt = buildPromptFromDNA(dna);
+  const result = await streamText({
+    model: getStoryModel(model),
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 1
+  });
+  return { stream: result.toAIStream(), dna };
+}

--- a/src/routes/api/stories/+server.ts
+++ b/src/routes/api/stories/+server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { StreamingTextResponse, streamText } from 'ai';
+import { generateNPCFromDNA } from '$lib/utils/npcDNA';
 
 import { getStoryModel } from '$lib/api/ai';
 import { authorize } from '$lib/api/auth';
@@ -14,8 +15,13 @@ export const config: import('@sveltejs/adapter-vercel').Config = {
 
 export const POST: RequestHandler = async ({ request }) => {
   try {
-    const { prompt, model } = (await request.json()) as { prompt: string; model: StoryModel };
-    if (!prompt) throw new Error('No prompt provided');
+    const { prompt, model, useDNA } = (await request.json()) as {
+      prompt?: string;
+      model: StoryModel;
+      useDNA?: boolean;
+    };
+
+    if (!useDNA && !prompt) throw new Error('No prompt provided');
 
     const { client, user } = await authorize(request);
     if (!user) throw error(401, 'Unauthorized');
@@ -25,16 +31,24 @@ export const POST: RequestHandler = async ({ request }) => {
 
     if (!coinsLeft || coinsLeft < price) throw error(403, 'Not enought coins');
 
-    const result = await streamText({
-      model: getStoryModel(model),
-      system: SYSTEM_PROMPT,
-      prompt,
-      temperature: 1
-    });
+    let stream;
+    if (useDNA) {
+      const dnaResult = await generateNPCFromDNA(model);
+      stream = dnaResult.stream;
+      log('story', 'Generating DNA-based story', { model });
+    } else {
+      const result = await streamText({
+        model: getStoryModel(model),
+        system: SYSTEM_PROMPT,
+        prompt,
+        temperature: 1
+      });
+      stream = result.toAIStream();
+      log('story', 'Generating story', { model, prompt });
+    }
     await client.records.update('profiles', user.profile.id, { coins: coinsLeft - price });
 
-    log('story', 'Generating story', { model, prompt });
-    return new StreamingTextResponse(result.toAIStream());
+    return new StreamingTextResponse(stream);
   } catch (err) {
     report('story', err);
     throw createServerError(err);


### PR DESCRIPTION
## Summary
- implement Python generator script for NPC DNA
- add rich NPC decoding prompt
- create helper to generate NPCs via DNA
- integrate DNA generation option in the stories API route
- allow toggling DNA generation in Biography Editor UI

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn check` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688427fbc950832ba9038f3da32479c7